### PR TITLE
2 new adware domains

### DIFF
--- a/RAW/Ads
+++ b/RAW/Ads
@@ -1,3 +1,5 @@
+gyppedsquiss.com
+hockeyhavoc.com
 0914.global.ssl.fastly.net
 0i.iqostaiwan.com
 0i.sh-cdn.com


### PR DESCRIPTION
- gyppedsquiss.com (980773)
- hockeyhavoc.com (980774)