### PR TITLE
removing zenfone.ru

### DIFF
--- a/Lists/Ads
+++ b/Lists/Ads
@@ -18610,7 +18610,6 @@ zen.agency
 zenaps.com
 zendesignfirm.com
 zendplace.pro
-zenfone.ru
 zenkreka.com
 zentr.cc
 zentrick.com


### PR DESCRIPTION
It is clearly a false-positive. A site about Asus Zenfone smartphones. Yes, it can be considered as marketing, but I think, it is too much :-)