### PR TITLE
Removing Strava

### DIFF
--- a/Lists/Tracking
+++ b/Lists/Tracking
@@ -57664,7 +57664,6 @@ stratifyd.com
 stratifyd.io
 stratigent.com
 strats.cashortrade.org
-strava.com
 stravito.com
 stravtrk.com
 strawburn.com


### PR DESCRIPTION
Strava is well-known sports tracking app. It means, the app is making a GPS track of your running, cycling etc activities and you can show the track to friends and public. Clearly false-positive.

strava.com