### PR TITLE
Typo

### DIFF
--- a/Lists/Tracking
+++ b/Lists/Tracking
@@ -34037,7 +34037,7 @@ openstat.com
 openstat.net
 openstat.org
 openstat.ru
-opentracker.emai
+opentracker.email
 opentracking.ru
 opentrack.org
 openwebanalytics.com


### PR DESCRIPTION
opentracker.emai (non-existent)
 ->
opentracker.email (exists)