### PR TITLE
Adding uptime.ru

### DIFF
--- a/Lists/Tracking
+++ b/Lists/Tracking
@@ -60680,6 +60680,7 @@ ups.data.cbc.ca
 upsight-api.com
 upsight.com
 uptime.com
+uptime.ru
 uptime-info.yandex.ru
 uptimerobot.com
 uptracs.com


### PR DESCRIPTION
In Russian: "Federal Independent Center of Monitoring and Analytics". In fact, it's like a government-funded spy service

Also, it exists in well-known Ru AdList, which is present in uBlock Origin by default