### PR TITLE
Removing elasticbeanstalk.*

### DIFF
--- a/Lists/Ads
+++ b/Lists/Ads
@@ -9620,8 +9620,6 @@ ela1.com
 elama.ru
 elasticad.net
 elasticads.com
-elasticbeanstalk.co
-elasticbeanstalk.com
 elated-part.pro
 eleadmedia.com
 eleavers.com


### PR DESCRIPTION
It is AWS. They have many random subdomains, as one can see in many blocklists, but in general, it is very bad solution to block them all

https://aws.amazon.com/elasticbeanstalk/ :

Elastic Beanstalk is a service for deploying and scaling web applications and services. Upload your code and Elastic Beanstalk automatically handles the deployment—from capacity provisioning, load balancing, and auto scaling to application health monitoring.

elasticbeanstalk.com
elasticbeanstalk.co