### PR TITLE
Update Tracking - removing elastic.co

### DIFF
--- a/Lists/Tracking
+++ b/Lists/Tracking
@@ -19369,7 +19369,6 @@ elabs8.com
 elanstudionola.com
 elasticbeanstalk-1185995375.us-east-1.elb.amazonaws.com
 elasticchange.com
-elastic.co
 elasticducks.com
 e.latimes.com
 elb-aws-va-visualiq-39389596.us-east-1.elb.amazonaws.com


### PR DESCRIPTION
elastic.co - false positive. ELK Stack is used for monitoring, but not for end user tracking, but for monitoring infrastructure