### PR TITLE
Block request by Foscam camera - security-device-access.ivyiot.io

### DIFF
--- a/Lists/Tracking
+++ b/Lists/Tracking
@@ -75998,6 +75998,7 @@ securiti.ai
 security.claroty.com
 security.iq.com
 securitymetrics.com
+security-device-access.ivyiot.io
 security-notify.com
 sedatebun.com
 sedge.aarp.org


### PR DESCRIPTION
Not sure why my Foscam camera, which isn't configured with Foscam Cloud, is trying to access this since latest firmware update.

<img width="993" height="237" alt="Screenshot-o7AO7U" src="https://github.com/user-attachments/assets/f246a4e2-1bcd-4956-a0ae-239d2eff27de" />
